### PR TITLE
Updated android build gradle version from 7.3.0-beta05 to 7.2.1

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -6,7 +6,7 @@ buildscript {
     }
 
     dependencies {
-        classpath 'com.android.tools.build:gradle:7.3.0-beta05'
+        classpath 'com.android.tools.build:gradle:7.2.1'
         classpath 'org.jetbrains.kotlin:kotlin-gradle-plugin:1.6.21'
         classpath 'com.mikepenz.aboutlibraries.plugin:aboutlibraries-plugin:8.9.4'
 

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
+#Mon Aug 01 16:24:39 WAT 2022
 distributionBase=GRADLE_USER_HOME
+distributionUrl=https://services.gradle.org/distributions/gradle-7.5-bin.zip
 distributionPath=wrapper/dists
-distributionSha256Sum=cb87f222c5585bd46838ad4db78463a5c5f3d336e5e2b98dc7c0c586527351c2
-distributionUrl=https\://services.gradle.org/distributions/gradle-7.5-bin.zip
-zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
+zipStoreBase=GRADLE_USER_HOME


### PR DESCRIPTION
Updated Android Gradle plugin version from 7.3.0-beta05 to 7.2.1 after getting this error while building the project "The project is using an incompatible version (AGP 7.3.0-beta05) of the Android Gradle plugin. Latest supported version is AGP 7.2.1"